### PR TITLE
Handle the worst case of 1-byte requests at 115200 baud.

### DIFF
--- a/src/driver/EnlyzePortSniffer.h
+++ b/src/driver/EnlyzePortSniffer.h
@@ -1,6 +1,6 @@
 //
 // PortSniffer - Monitor the traffic of arbitrary serial or parallel ports
-// Copyright 2020 Colin Finck, ENLYZE GmbH <c.finck@enlyze.com>
+// Copyright 2020-2021 Colin Finck, ENLYZE GmbH <c.finck@enlyze.com>
 //
 // SPDX-License-Identifier: MIT
 //
@@ -16,8 +16,14 @@
 
 #define CONTROL_DEVICE_NAME_STRING          L"\\Device\\EnlyzePortSniffer"
 #define CONTROL_SYMBOLIC_LINK_NAME_STRING   L"\\DosDevices\\EnlyzePortSniffer"
-#define MAX_LOG_ENTRIES_PER_PORT            32
 #define POOL_TAG                            (ULONG)'nSoP'
+
+// The worst case is a serial port at 115200 baud, which is read via 1-byte requests.
+// 115200 baud makes 14400 bytes/second. Considering that the PortSniffer-Tool polls the
+// driver in 10 millisecond intervals (100 times/second), we need to buffer up to
+// 144 1-byte log entries.
+// Choose 160 (divisible by 32) as the upper limit here to be on the safe side.
+#define MAX_LOG_ENTRIES_PER_PORT            160
 
 
 typedef struct _PORTLOG_ENTRY

--- a/src/tool/monitoring.c
+++ b/src/tool/monitoring.c
@@ -138,7 +138,16 @@ HandleMonitorParameter(
         &cbReturned,
         NULL))
     {
-        fprintf(stderr, "DeviceIoControl failed for PORTSNIFFER_IOCTL_CONTROL_RESET_PORT_MONITORING, last error is %lu.\n", GetLastError());
+        if (GetLastError() == ERROR_FILE_NOT_FOUND)
+        {
+            fprintf(stderr, "The PortSniffer Driver is not attached to %S!\n", pwszPort);
+            fprintf(stderr, "Please run this tool using the /attach option.\n");
+        }
+        else
+        {
+            fprintf(stderr, "DeviceIoControl failed for PORTSNIFFER_IOCTL_CONTROL_RESET_PORT_MONITORING, last error is %lu.\n", GetLastError());
+        }
+
         goto Cleanup;
     }
 
@@ -170,8 +179,9 @@ HandleMonitorParameter(
             }
             else if (GetLastError() == ERROR_FILE_NOT_FOUND)
             {
-                fprintf(stderr, "The PortSniffer Driver is not attached to %S!\n", pwszPort);
+                fprintf(stderr, "The PortSniffer Driver is no longer attached to %S!\n", pwszPort);
                 fprintf(stderr, "Please run this tool using the /attach option.\n");
+                goto Cleanup;
             }
             else
             {

--- a/src/tool/monitoring.c
+++ b/src/tool/monitoring.c
@@ -1,6 +1,6 @@
 //
 // PortSniffer - Monitor the traffic of arbitrary serial or parallel ports
-// Copyright 2020 Colin Finck, ENLYZE GmbH <c.finck@enlyze.com>
+// Copyright 2020-2021 Colin Finck, ENLYZE GmbH <c.finck@enlyze.com>
 //
 // SPDX-License-Identifier: MIT
 //
@@ -154,8 +154,6 @@ HandleMonitorParameter(
     // Fetch new port log entries from our driver until we are terminated.
     while (!_bTerminationRequested)
     {
-        Sleep(250);
-
         if (!DeviceIoControl(hPortSniffer,
             (DWORD)PORTSNIFFER_IOCTL_CONTROL_POP_PORTLOG_ENTRY,
             &PopRequest,
@@ -167,6 +165,7 @@ HandleMonitorParameter(
         {
             if (GetLastError() == ERROR_NO_MORE_ITEMS)
             {
+                Sleep(10);
                 continue;
             }
             else if (GetLastError() == ERROR_FILE_NOT_FOUND)


### PR DESCRIPTION
The worst case is a serial port at 115200 baud, which is read via 1-byte requests.
115200 baud makes 14400 bytes/second.

PortSniffer-Tool has been changed to poll the driver in 10 millisecond intervals (100 times/second), which means that the driver needs to buffer up to 144 1-byte log entries.
Choose 160 (divisible by 32) as the upper limit here to be on the safe side.