### PR TITLE
Dispatch requests from the Device I/O Queue in parallel.

### DIFF
--- a/src/driver/EnlyzePortSniffer.c
+++ b/src/driver/EnlyzePortSniffer.c
@@ -681,7 +681,7 @@ PortSnifferFilterEvtDeviceAdd(
     }
 
     // Register callbacks for read and write requests.
-    WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&ioQueueConfig, WdfIoQueueDispatchSequential);
+    WDF_IO_QUEUE_CONFIG_INIT_DEFAULT_QUEUE(&ioQueueConfig, WdfIoQueueDispatchParallel);
     ioQueueConfig.EvtIoRead = PortSnifferFilterEvtIoRead;
     ioQueueConfig.EvtIoWrite = PortSnifferFilterEvtIoWrite;
 


### PR DESCRIPTION
This fixes using PortSniffer when read and write requests come in nearly simultaneously (e.g. when using a serial loopback adapter as an echo server).
Fixes #4