### PR TITLE
Improve uninstallation, upgrades, and messages when things go wrong.

### DIFF
--- a/src/tool/PortSniffer-Tool.c
+++ b/src/tool/PortSniffer-Tool.c
@@ -45,7 +45,10 @@ OpenPortSniffer(void)
     if (hPortSniffer == INVALID_HANDLE_VALUE)
     {
         fprintf(stderr, "Could not open \"\\\\.\\EnlyzePortSniffer\", last error is %lu.\n", GetLastError());
-        fprintf(stderr, "Either the PortSniffer Driver is not installed or not attached to any port.\n");
+        fprintf(stderr, "This can have various reasons:\n");
+        fprintf(stderr, "- The PortSniffer Driver is not installed\n");
+        fprintf(stderr, "- The PortSniffer Driver is not attached to any port\n");
+        fprintf(stderr, "- You have not turned off Driver Signature Enforcement at boot\n");
     }
 
     return hPortSniffer;

--- a/src/tool/PortSniffer-Tool.h
+++ b/src/tool/PortSniffer-Tool.h
@@ -100,3 +100,10 @@ HandleDetachParameter(
 
 int
 HandleVersionParameter(void);
+
+BOOL
+VerifyDriverAndToolVersions(
+    __in HANDLE hPortSniffer,
+    __in BOOL bAlwaysPrintVersions,
+    __out_opt PPORTSNIFFER_GET_VERSION_RESPONSE pResponse
+    );

--- a/src/tool/installation.c
+++ b/src/tool/installation.c
@@ -439,6 +439,9 @@ HandleUninstallParameter(void)
         goto Cleanup;
     }
 
+    CloseServiceHandle(hService);
+    hService = NULL;
+
     // Delete the driver.
     if (!_GetDriverDestinationPath(wszDriverDestinationPath))
     {

--- a/src/tool/installation.c
+++ b/src/tool/installation.c
@@ -442,15 +442,20 @@ HandleUninstallParameter(void)
     CloseServiceHandle(hService);
     hService = NULL;
 
-    // Delete the driver.
+    // Mark the driver file for deletion on next reboot.
+    //
+    // It was possible to delete it right away up to Windows 10, but since then the
+    // driver file is locked in memory as long as the driver is loaded.
+    // Windows neither provides a way to unload a _filter_ driver attached to a
+    // _legacy_ device without rebooting the entire system.
     if (!_GetDriverDestinationPath(wszDriverDestinationPath))
     {
         goto Cleanup;
     }
 
-    if (!DeleteFileW(wszDriverDestinationPath))
+    if (!MoveFileExW(wszDriverDestinationPath, NULL, MOVEFILE_DELAY_UNTIL_REBOOT))
     {
-        fprintf(stderr, "DeleteFileW failed, last error is %lu.\n", GetLastError());
+        fprintf(stderr, "MoveFileExW failed, last error is %lu.\n", GetLastError());
         goto Cleanup;
     }
 
@@ -463,6 +468,7 @@ HandleUninstallParameter(void)
     }
 
     printf("The PortSniffer Driver has been uninstalled successfully!\n");
+    printf("A reboot is required to complete the uninstallation.\n");
     iReturnValue = 0;
 
 Cleanup:

--- a/src/tool/monitoring.c
+++ b/src/tool/monitoring.c
@@ -306,6 +306,12 @@ HandleMonitorParameter(
         goto Cleanup;
     }
 
+    // Verify that driver and tool are compatible.
+    if (!VerifyDriverAndToolVersions(hPortSniffer, FALSE, NULL))
+    {
+        goto Cleanup;
+    }
+
     // Start monitoring on this port.
     if (!DeviceIoControl(hPortSniffer,
         (DWORD)PORTSNIFFER_IOCTL_CONTROL_RESET_PORT_MONITORING,

--- a/src/version.h
+++ b/src/version.h
@@ -10,7 +10,7 @@
 // We use Semantic Versioning (https://semver.org) without a patch version here.
 // Increase the major version on API-incompatible changes, increase the minor version on API-compatible changes.
 #define PORTSNIFFER_MAJOR_VERSION       2
-#define PORTSNIFFER_MINOR_VERSION       0
+#define PORTSNIFFER_MINOR_VERSION       1
 
 // The following two lines of macro magic turn arbitrary preprocessor constants into strings.
 #define STRINGIFY_INTERNAL(x)           #x


### PR DESCRIPTION
This PR puts an end to uninstalling without a system reboot.
Windows requires me to stop the driver service before it unloads the driver from memory, but stopping is not possible for a _filter_ driver.
You are supposed to restart the entire stack where the filter driver is attached to, but this is neither possible for _legacy_ devices like COM ports.
On top of that, Windows 10 locks the driver file in memory and doesn't allow to delete it.

Therefore, I'm going on the safe side and always require a reboot after uninstallation.
I'm also now verifying driver and tool versions for compatibility before starting monitoring.
Finally, this PR improves error messages in case things still go wrong.