### PR TITLE
Don't buffer stdout to enable live monitoring under all circumstances.

### DIFF
--- a/src/tool/PortSniffer-Tool.c
+++ b/src/tool/PortSniffer-Tool.c
@@ -60,6 +60,7 @@ wmain(
     __in wchar_t* argv[]
     )
 {
+    setbuf(stdout, NULL);
     printf("**********************************************************************\n");
     printf("ENLYZE PortSniffer Tool " PORTSNIFFER_VERSION_COMBINED "\n");
     printf("Copyright " COPYRIGHT_YEAR_STRING " Colin Finck, ENLYZE GmbH <c.finck@enlyze.com>\n");


### PR DESCRIPTION
This fixes live monitoring when stdout is redirected, e.g. using `PortSniffer-Tool /monitor COM2 CRW | tee log.log`